### PR TITLE
Update authoring.html.erb.md

### DIFF
--- a/source/authoring.html.erb.md
+++ b/source/authoring.html.erb.md
@@ -13,27 +13,7 @@ status: editors-draft
 {:toc}
 
 {:.attach_permalink}
-## Provide alternative text for all images
-
-[ ... Tip description goes here ... ]
-
-{:.attach_permalink}
 ##  Keep it short and simple 
-
-[ ... Tip description goes here ... ]
-
-{:.attach_permalink}
-## Make the text in links clear
-
-[ ... Tip description goes here ... ]
-
-{:.attach_permalink}
-## Provide short, meaningful headings to break-up text
-
-[ ... Tip description goes here ... ]
-
-{:.attach_permalink}
-## Provide transcripts and captions for audio/visual content
 
 [ ... Tip description goes here ... ]
 
@@ -43,7 +23,12 @@ status: editors-draft
 [ ... Tip description goes here ... ]
 
 {:.attach_permalink}
-## Use informative and unique page titles
+## Expand all acronyms on their first use
+
+[ ... Tip description goes here ... ]
+
+{:.attach_permalink}
+## Make the text in links clear
 
 [ ... Tip description goes here ... ]
 
@@ -53,12 +38,27 @@ status: editors-draft
 [ ... Tip description goes here ... ]
 
 {:.attach_permalink}
-## Expand all acronyms on their first use
+## Provide short, meaningful headings to break-up text
+
+[ ... Tip description goes here ... ]
+
+{:.attach_permalink}
+## Use informative and unique page titles
 
 [ ... Tip description goes here ... ]
 
 {:.attach_permalink}
 ## Use consistent layout, format, and language between pages
+
+[ ... Tip description goes here ... ]
+
+{:.attach_permalink}
+## Provide alternative text for all images
+
+[ ... Tip description goes here ... ]
+
+{:.attach_permalink}
+## Provide transcripts and captions for audio/visual content
 
 [ ... Tip description goes here ... ]
 


### PR DESCRIPTION
moved images and multimedia to the bottom to keep all text-related tips together (alternatively, they could be at the top)
re-positioned some other tips to group related ideas (e.g. short-n-simple + complex-words + acronyms all seem related)