### PR TITLE
Tersify contrast between colors

### DIFF
--- a/source/designing.html.erb.md
+++ b/source/designing.html.erb.md
@@ -20,7 +20,7 @@ These introductory tips cover the basics of accessible user interface and visual
 {:.attach_permalink}
 ## Provide sufficient contrast between colors
 
-Text needs to have sufficient contrast between foreground and background colors. This includes text on images, buttons, and other elements. A minimum contrast ratio is required by the Web Content Accessibility Guidelines (WCAG) and guidance on how to check contrast ratio is available. This does not apply for logos, or incidental text, such as text that happens to be in a photograph.
+Text needs to have sufficient contrast between foreground and background colors. This includes text on top of images. Interactive elements, like buttons, additionally need to have enough contrast to surrounding elements. This does not apply for logos, or incidental text, such as text that happens to be in a photograph. For more information on the minimum contrast ratio as required by the Web Content Accessibility Guidelines (WCAG) and how to check the contrast, see below.
 
 Note that "contrast" is used as a short form for the more technically correct term "luminance contrast".
 


### PR DESCRIPTION
[medium] Rationale:

* I think we should more explicitly call out different examples.
* I think the part with the button was confusing as the sentence before just talks about text. And while that is true, buttons need also have enough contrast to their surrounding elements.
* [strong] The sentence “A minimum contrast ratio is required by the Web Content Accessibility Guidelines (WCAG) and guidance on how to check contrast ratio is available.” doesn’t say anything to me. It is not actionable. At least the guidance and how to should be linked. If you don’t want to link those inline, a sentence like “For more information on the minimum contrast ratio as required by the Web Content Accessibility Guidelines (WCAG) and how to check the contrast, see below.” (I have added that sentence to the tip after writing this up.)