### PR TITLE
Use Example.com (or .net or .org) for the email address

### DIFF
--- a/source/designing.html.erb.md
+++ b/source/designing.html.erb.md
@@ -343,7 +343,7 @@ Provide feedback for any page interactions, such as confirmation of form submiss
         </div>
         <div class="row error">
           <label class="required" for="email5"><span class="fa fa-exclamation-triangle"></span> E-mail ✻</label>
-          <input type="text" id="email5" name="email" value="superbear@@hq.space" aria-invalid="true" aria-describedby="error_email">
+          <input type="text" id="email5" name="email" value="superbear@@hq.example.com" aria-invalid="true" aria-describedby="error_email">
         </div>
         <div class="row">
           <label for="website3">Website</label>


### PR DESCRIPTION
Such domain’s are there for examples and that won’t change. With ICANN’s crazy TLDs (like accessibility.rocks ;-) we should be safe.