### PR TITLE
tersification

### DIFF
--- a/source/designing.html.erb.md
+++ b/source/designing.html.erb.md
@@ -174,7 +174,7 @@ While color can be useful to convey information, color should not be the only wa
 {:.attach_permalink}
 ## Ensure interactive elements are easy to identify
 
-Provide distinct styles for interactive elements, such as links, buttons, and other controls, to make them easy to distinguish and identify. Those styles include interaction specific changes of appearance, for example in the event of a mouse hover, keyboard focus, and touch-screen activation. This helps users to identify the state of the element.
+Provide distinct styles for interactive elements, such as links and buttons, to make them easy to identify. For example, change the appearance of links on mouse hover, keyboard focus, and touch-screen activation.
 
 {::nomarkdown}
 <%= example :start, :plural %>


### PR DESCRIPTION
In the first sentence, I suggest we just use distinguish OR identify, *not* both ("distinguish and identify") -- probably identify since you have distinct in the beginning of the sentence. [low]

"and other controls" is redundant with "such as"