### PR TITLE
see comments

### DIFF
--- a/source/designing.html.erb.md
+++ b/source/designing.html.erb.md
@@ -454,8 +454,6 @@ Provide a text description to communicate what information or function images ar
 [... Text descriptions for: ... ]
 [... Home icon with functional text 'Home' ...]
 
-[... Photo of snow vista with descriptive text 'Used to evoke a sense of desire in snowboarders' ...]
-
 <%= example :end %>
 {:/}
 


### PR DESCRIPTION
I strongly disagree with "[... Photo of snow vista with descriptive text 'Used to evoke a sense of desire in snowboarders' ...]" --some people would consider that decorative and would not want alt text. Let's come up with example(s) that are more clear-cut.

I'm not keen on [... Home icon with functional text 'Home' ...] either.

some ideas:
* For example, appropriate text alternative for a search button would be "search", not "magnifying glass".
* maybe use an example from BAD. Could use the "logo"and show both the too detailed bad alt and the good alt.
* http://www.w3.org/WAI/intro/cycle.png alt = illustration with arrow going from content at the top through authoring tools at left to content at the bottom, and an arrow going from the content at the bottom through assistive technologies and user agents at the right and back to content at the top" -- but maybe too complex
* http://www.w3.org/WAI/intro/iui-scroll.png  alt="Illustration of 4 scroll down user actions (described in the main content) going into a filter labeled IndieUI Events. Under filter is 'scrollrequest(x/y)', and an arrow pointing to it from a Web App." -- but maybe too complex