### PR TITLE
spacing & headings

### DIFF
--- a/source/designing.html.erb.md
+++ b/source/designing.html.erb.md
@@ -384,9 +384,9 @@ Provide feedback for interactions, such as confirming form submission, alerting 
 {:/}
 
 {:.attach_permalink}
-## Use headings and spacing to group related content
+## Use spacing and headings to group related content
 
-Provide clear headings to group content, reduce clutter, and make it easier to scan. Use whitespace to make relationships between content and elements more apparent.
+Use whitespace and proximity to make relationships between content more apparent. Style headings to group content, reduce clutter, and make it easier to scan. 
 
 {::nomarkdown}
 <%= learn_more %>


### PR DESCRIPTION
Providing headings is more a writing task -- so I downplayed it from spacing, and changed "provide" to "style", which is more the designing task. [medium]
I think "proximity" is an understandable term even if you don't have the background in the concept. [low]
"content" includes "elements" so don't need both [low]