### PR TITLE
headings tweak [low]

### DIFF
--- a/source/designing.html.erb.md
+++ b/source/designing.html.erb.md
@@ -386,7 +386,7 @@ Provide feedback for interactions, such as confirming form submission, alerting 
 {:.attach_permalink}
 ## Use headings and spacing to group related content
 
-Provide clear headings to group content, reduce clutter, and make it easier to scan. Use whitespace to make relationships between content and elements more apparent.
+Provide clear headings to group content and make it easier to scan and understand content. Use whitespace to make relationships between content and elements more apparent.
 
 {::nomarkdown}
 <%= learn_more %>


### PR DESCRIPTION
Headings do not in and of themselves reduce clutter. They make it *appear* less cluttered, largely because they have inherent whitespace.

But really headings are more about improving understandability and scanability.

[I think I have another open pull request on this one, so they'll need munging]