### PR TITLE
Deleted Two Tips

### DIFF
--- a/source/writing.html.erb.md
+++ b/source/writing.html.erb.md
@@ -51,26 +51,15 @@ Write in short, clear sentences and paragraphs, as appropriate for the context. 
 {:/}
 
 {:.attach_permalink}
-## Avoid using overly complex words and phrases
 
-Avoid using words more complicated than the audience needs. Some audiences, such as in doctors or engineers, require complex terminology, but still seek for opportunities to simplify. When content requires possibly unfamiliar terms, include a glossary. 
+## Know your audience and write for them
 
-{::nomarkdown}
-<%= example %>
-{:/}
+If you are writing to the general public, it's useful to use language that is very basic and not overly complex. If the writing is geared toward readers of a particular niche, then ensure complex language, words, or phrases is clearly defined on the first use. It is also helpful to reiterate the definition for such language when it is re-introduced after having been unused within the document you are authoring. 
 
-[... Example using medical terminology against layman terminology... ]
-
-{::nomarkdown}
-<%= example :end %>
-{:/}
-
-{::nomarkdown}
-<%= tip :end %>
-<%= tip %>
-{:/}
+**Example Here**
 
 {:.attach_permalink}
+
 ## Provide meaningful link text
 
 Try to write link text so that it would make sense out of context. Link text should describe the content of the link target in a meaningful way. Avoid using link text such as 'click here', 'find out more', or 'read more'. Where the link target is not HTML, indicate the document type and approximate size in the link text.
@@ -175,33 +164,7 @@ For audio-only content, such a podcast, provide transcripts. Include everything 
 {:/}
 
 {:.attach_permalink}
-## Expand acronyms on their first use
 
-When first used on a page, ensure that acronyms are fully expanded. Follow the expansion with the abbr. Some extremely common acronyms may be better known than the expanded form, for example, BBC, or HTML. In such cases, an expansion may not be necessary, although avoid assuming internal organizational acronyms are as well known.
-
-{::nomarkdown}
-<%= example %>
-{:/}
-
-<div class="">
-  <figure>
-    <figcaption>Example paragraph introducing and then referencing an acronym</figcaption>
-    <div>
-      <p>Since the passage of the Communications and Video Accessibility Act (CVAA), we have seen increased use of auto generated captions. While this may be well-intentioned, auto-captioning is still quite unreliable and error-prone and does not usually fulfill the intention of the <abbr title="Communications and Video Accessibility Act">CVAA</abbr> legislation.</p>
-    </div>
-  </figure>
-</div>
-
-{::nomarkdown}
-<%= example :end %>
-{:/}
-
-{::nomarkdown}
-<%= tip :end %>
-<%= tip %>
-{:/}
-
-{:.attach_permalink}
 ## Learn more about accessibility
 
 These tips are important points to consider when writing accessible content, but there is always more to learn. The following resources will help you find out more about accessibility, why it is important, and what guidelines exist to help support people with disabilities accessing the web.


### PR DESCRIPTION
1. Recommending the dumbing down of language is contrary to the rest of the tips. A)The majority of the tips here are not about the actual content but rather the semantics of making something readable. We should not be in a position to inform an author *what to write, just how to make it easier to understand and conceptualize.  B) It's It's also unhelpful for many authors: Firstly, it can be really difficult to express oneself using simpler language when an author isn't used to writing a certain way. Secondly, decreasing the educational level prohibits people from learning. 

2. Announcing Acronyms violates AP Style (among others), which is used by several Federal agencies (including I believe by the FCC). It's the most common flaw in this advice. Further, WCAG makes no discrimination of popular acronyms over others and with good reason: WWF (World Wildlife Fund), BBC (British Broadcasting Corporation), CIA (Culinary Institute of America), or WTF (World Trade Federation) all have seemingly dubious counterparts that are well known in *other* circles of the web.  

I think we should discuss approaches to this further. It's not based in any factual advice aside from a blog post from TPG.