### PR TITLE
suggestions for avoid and correct mistakes

### DIFF
--- a/source/developing.html.erb.md
+++ b/source/developing.html.erb.md
@@ -140,7 +140,7 @@ Associate the `<label>` element with form elements using the *for* and *id* attr
 {:.attach_permalink}
 ## Help users avoid and correct mistakes
 
-Be as forgiving of format as possible when accepting information. For example, accept phone numbers that include spaces and delete the spaces as needed. Clearly identify errors that cannot be auto-corrected. Provide an in-page link for easy access from the error to the field when feasible. 
+Be as forgiving of format as possible when accepting information; for example, accept phone numbers that include spaces and delete the spaces as needed. Add clear instructions for form completion if there is any complexity in the inputs expected. Clearly identify errors that cannot be auto-corrected and provide an in-page link for easy access from the error to the field when feasible. 
 
 {::nomarkdown}
 <%= example %>


### PR DESCRIPTION
1. suggest adding a sentence re providing instructions - editors discretion to include and/or refine
2. BTW, I question the need for some <abbr> inclusion such as <abbr title="Web Content Accessibility Guidelines">WCAG</abbr> - people reading thsi page will know it as WCAG and adding <abbr title="Web Content Accessibility Guidelines">WCAG</abbr> increases screen reader verbosity :(