### PR TITLE
suggestions for meaning for non-standard interactive elements

### DIFF
--- a/source/developing.html.erb.md
+++ b/source/developing.html.erb.md
@@ -207,7 +207,7 @@ Ensure that the order of elements in the code matches the logical order of the i
 {:.attach_permalink}
 ## Provide meaning for non-standard interactive elements 
 
-Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> to provide information on function and state for custom widgets, such as accordions and custom-made buttons. For example, `role='button'` and `state='pressed'`. Additional code is required to implement the behavior of such widgets, such as pressing interaction.
+Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> to provide information on function and state for custom widgets, such as accordions and custom-made buttons. For example, `role='button'` and `state='pressed'`, however ARIA to use an ARIA role when there is a native HTML role. Additional code is required to implement the behavior of such widgets, such as pressing interaction.
 
 {::nomarkdown}
 <%= example %>


### PR DESCRIPTION
1. again, is the <abbr> element required? if used it should reflect the full acronym, not just "ARIA"
2. don't like the [`role='button'`] example - HTML code should be used wherever it can and WAI-ARIA just used for enhancements and additional clarity. see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role and others