### PR TITLE
Update writing2.html.erb.md

### DIFF
--- a/source/writing2.html.erb.md
+++ b/source/writing2.html.erb.md
@@ -291,7 +291,7 @@ Assign alternative text to every image. Text must clearly describe the informati
 <%= related_issues 163 %>
 {:/}
 
-For audio-only content, such a podcast, provide transcripts. Include everything that is spoken, and descriptions of sounds that are important for understanding the content, for example 'squeaking door'. Provide this information, including the audio description, as captions when audio is used to accompany visual content, such as animations and video. The requirements vary for pre-recorded and live content.
+For audio-only content, such a podcast, provide transcripts. Include everything that is spoken, and descriptions of sounds that are important for understanding the content, for example 'squeaking door'. Also provide this information, including the audio description, as captions when audio is used to accompany visual content, such as animations and video. The requirements vary for pre-recorded and live content.
 
 {::nomarkdown}
 <%= learn_more %>


### PR DESCRIPTION
Suggested edit to multimedia tip (editors discretion). 
Transcripts are still very useful for video as they a) allow skimming the content and b) maximise SEO - thus I suggest we say "also provide captions for video ..." rather than presenting them as the alternative for video. 
I personally seldom watch videos or animations longer than a few minutes due to being time-poor and many of my colleagues are in the same position - I'll skip them if there is no transcript to speed-read!