### PR TITLE
Write meaningful text alternatives for images

### DIFF
--- a/source/writing.html.erb.md
+++ b/source/writing.html.erb.md
@@ -233,7 +233,7 @@ Write link text so that it describes the content of the link target in a meaning
 {:.attach_permalink}
 ## Write meaningful text alternatives for images
 
-For every image, write alternative text that provides the information or function of the image. For images that are just decorative, use empty alternative text.
+For every image, write alternative text that provides the information or function of the image. For images that are purely decorative, use empty alternative text.
 
 {::nomarkdown}
 <%= example %>

--- a/source/writing.html.erb.md
+++ b/source/writing.html.erb.md
@@ -233,7 +233,7 @@ Write link text so that it describes the content of the link target in a meaning
 {:.attach_permalink}
 ## Write meaningful text alternatives for images
 
-Assign alternative text to every image, to clearly describe the information or function represented by the image. Use empty alternative text when an image is purely decorative.
+For every image, write alternative text that provides the information or function of the image. For images that are just decorative, use empty alternative text.
 
 {::nomarkdown}
 <%= example %>


### PR DESCRIPTION
[mild] suggest not using "describes" since that insinuates to too wordy alt text
[mild] not say "assign" 'cause writing task is to write it, but they might not be setting it in the code :)

the full text would be:
... that provides the information presented by the image or the function of the image.
I think can shorten it as I've suggested.