### PR TITLE
[editorial] Associate all form elements with labels

### DIFF
--- a/source/developing.html.erb.md
+++ b/source/developing.html.erb.md
@@ -17,9 +17,9 @@ These tips introduce some basic considerations to help you get started developin
 {:/}
 
 {:.attach_permalink}
-## Associate all form elements with labels
+## Associate a label with every form control
 
-This can be achieved using the `<label>` element with a `for` attribute that is linked to the `id` attribute of the form element, or using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes. In specific situations it may be acceptable to hide `<label>` elements visually, but in most cases labels are needed to help all readers understand the required input.
+Use a `for` attribute on the `<label>` element linked to the `id` attribute of the form element, or using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes. In specific situations it may be acceptable to hide `<label>` elements visually, but in most cases labels are needed to help all readers understand the required input.
 
 {::nomarkdown}
 <%= example 'Using <code>for</code> and <code>id</code> attributes' %>

--- a/source/developing.html.erb.md
+++ b/source/developing.html.erb.md
@@ -19,7 +19,7 @@ These tips introduce some basic considerations to help you get started developin
 {:.attach_permalink}
 ## Associate all form elements with labels
 
-Associate a label with every form control. This can be achieved using the `<label>` element with linked `for` and `id` attributes, or using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes. In specific situations it may be acceptable to hide `<label>` elements visually, but in most cases labels are needed to help all readers understand the required input.
+This can be achieved using the `<label>` element with a `for` attribute that is linked to the `id` attribute of the form element, or using <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> attributes. In specific situations it may be acceptable to hide `<label>` elements visually, but in most cases labels are needed to help all readers understand the required input.
 
 {::nomarkdown}
 <%= example 'Using <code>for</code> and <code>id</code> attributes' %>


### PR DESCRIPTION
The heading says: “Associate all form elements with labels”, the first sentence says “Associate a label with every form control.” – I think that is redundant information. Then one time elements and one time controls is used to describe form elements and the order of form control/element is changed which confused me.

Proposal: Drop the first sentence, the heading is descriptive enough.

I also don’t know if “linked for and id” attributes is clear.