### PR TITLE
Update designing: Add 1.4.6 for contrast

### DIFF
--- a/_tips/designing.md
+++ b/_tips/designing.md
@@ -90,12 +90,13 @@ Foreground text needs to have sufficient contrast with background colors. This i
 
 * **WCAG**
   * [Contrast (Minimum) 1.4.3](/WAI/WCAG21/quickref/#contrast-minimum) ([Understanding 1.4.3](/WAI/WCAG21/Understanding/contrast-minimum))
+  * [Contrast (Enhanced) 1.4.6](/WAI/WCAG21/quickref/#contrast-enhanced) ([Understanding 1.4.6](/WAI/WCAG21/Understanding/contrast-enhanced.html))
 * **User Story**
   * [How a user with "color blindness" experiences the Web](/people-use-web/user-stories/#shopper)
 * **Easy Check**
   * [How to check contrast ratio](/test-evaluate/preliminary/#contrast)
 * **Support Tools**
-  * [List of tools to help determine contrast ratio](/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html#visual-audio-contrast-contrast-resources-head)
+  * [List of tools to help determine contrast ratio](/WCAG21/Understanding/contrast-minimum#resources)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}


### PR DESCRIPTION
Fixes https://github.com/w3c/wai-website/issues/727

* Add SC 1.4.6 for contrast
* Update link from WCAG 2.0 to WCAG 2.1

not changed:
* Reference to SC 1.4.11, because the example is only about text contrast. For 1.4.11 a new example would have to be designed