### PR TITLE
Make "Tips for Getting Started" ready for translations

### DIFF
--- a/_tips/acknowledgements.md
+++ b/_tips/acknowledgements.md
@@ -1,6 +1,20 @@
 ---
+# Do not translate Acknowledgements page for now.
 title: Acknowledgements
+nav_title: Acknowledgements
+lang: en
+last_updated: 2016-04-15
+
+github:
+  repository: w3c/wai-quick-start
+  path: '_tips/acknowledgements.md'
+
+permalink: /tips/acknowledgements/
+ref: /tips/acknowledgements/
+
 nosidenav: true
+
+acknowledgements: /tips/acknowledgements/
 footer: >
   <p>
     <strong>Status:</strong>
@@ -12,7 +26,7 @@ footer: >
     <a href="https://www.w3.org/People/#kevin">Kevin White</a>,
     <a href="https://www.w3.org/People/shadi">Shadi Abou-Zahra</a>, and
     <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a>.
-    <a href=".">Acknowledgements</a>.
+    ACKNOWLEDGEMENTS.
     Developed by the <a href="https://www.w3.org/WAI/EO/">Education and Outreach Working Group (EOWG)</a>.
     Developed with support from the <a href="https://www.w3.org/WAI/DEV/">WAI-DEV project</a>, co-funded by the European Commission <abbr title="Information Society Technologies">IST</abbr> Programme.
       </p>

--- a/_tips/designing.md
+++ b/_tips/designing.md
@@ -1,36 +1,48 @@
 ---
+# Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".title: Tips for Getting Started
+
 title: "Designing for Web Accessibility – Tips for Getting Started"
 title_html: "Designing for Web Accessibility"
 nav_title: Tips for Designing
-ref: /tips/designing/   # Do not change this
-permalink: /tips/designing/   # add language code  /tips/designing/@@
-lang: en   # change language code
-navigation:
-  previous: /tips/writing/
-  next: /tips/developing/
-github:
-   repository: w3c/wai-quick-start
-   path: '_tips/designing.md'   # add language code designing.@@.md
-last_updated: 2019-01-09   # change to date of translation
-# translators:
-# - name: "Your Name"
-# contributors:
-# - name: "Other Name"
+lang: en  # Change "en" to the translated-language shortcode
+last_updated: 2019-01-09   # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
 resource:
-  ref: /tips/
+  ref: /tips/  # Do not change this
+
 navigation:
-  previous: /tips/writing/
-  next:     /tips/developing/
+  previous: /tips/writing/ # Do not change this
+  next: /tips/developing/ # Do not change this
+
+# translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
+# - name: "Jan Doe"   # Replace Jan Doe with translator name
+# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple translators
+# contributors:
+# - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
+# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
+
+github:
+  repository: w3c/wai-quick-start
+  path: '_tips/designing.md'   # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
+
+permalink: /tips/designing/   # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
+ref: /tips/designing/   # Do not change this
 
 ext_css: tips.css
 title_icon: /tips/img/icons.svg#designing
 
-footer: >   # translate text and dates; do not update dates
-  <p><strong>Date:</strong> Minor update 9 January 2019. Updated 15 April 2016. First published September 2015.</p>
-  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/kevin">Kevin White</a>, <a href="https://www.w3.org/People/shadi">Shadi Abou-Zahra</a>, and <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. <a href="https://w3c.github.io/wai-website/tips/acknowledgements/">Acknowledgements</a>.</p>
-  <p>Developed by the <a href="https://www.w3.org/WAI/EO/">Education and Outreach Working Group (EOWG)</a>. Developed with support from the <a href="https://www.w3.org/WAI/DEV/">WAI-DEV project</a>, co-funded by the European Commission <abbr title="Information Society Technologies">IST</abbr> Programme.</p>
+acknowledgements: /tips/acknowledgements/
 
+# In the footer below:
+# Do not change the dates
+# Do not translate ACKNOWLEDGEMENTS
+# Translate the other words, including "Date:" and "Editors:"
+# Translate the Working Group name. Leave the Working Group acronym in English.
+footer: >
+  <p><strong>Date:</strong> Minor update 9 January 2019. Updated 15 April 2016. First published September 2015.</p>
+  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/kevin">Kevin White</a>, <a href="https://www.w3.org/People/shadi">Shadi Abou-Zahra</a>, and <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. ACKNOWLEDGEMENTS.</p>
+  <p>Developed by the <a href="https://www.w3.org/WAI/EO/">Education and Outreach Working Group (EOWG)</a>. Developed with support from the <a href="https://www.w3.org/WAI/DEV/">WAI-DEV project</a>, co-funded by the European Commission <abbr title="Information Society Technologies">IST</abbr> Programme.</p>
 ---
 
 {::nomarkdown}
@@ -345,7 +357,7 @@ Ensure that all fields have a descriptive label adjacent to the field. For left-
   * [Labels or Instructions 3.3.2](/WAI/WCAG21/quickref/#labels-or-instructions) ([Understanding 3.3.2](/WAI/WCAG21/Understanding/labels-or-instructions))
   * [Headings and Labels 2.4.6](/WAI/WCAG21/quickref/#headings-and-labels) ([Understanding 2.4.6](/WAI/WCAG21/Understanding/headings-and-labels))
 * **Tutorial**
-  * [Visual position of label text](/WAI/tutorials/forms/labels/#visual-position-of-label-text)
+  * [Visual position of label text](/tutorials/forms/labels/#visual-position-of-label-text)
 * **User Story**
   * [How clear labelling can help someone with cognitive difficulties](/people-use-web/user-stories/#supermarketassistant)
 
@@ -410,7 +422,7 @@ Provide feedback for interactions, such as confirming form submission, alerting 
   * [Labels or Instructions 3.3.2](/WAI/WCAG21/quickref/#labels-or-instructions) ([Understanding 3.3.2](/WAI/WCAG21/Understanding/labels-or-instructions))
   * [Error Suggestion 3.3.3](/WAI/WCAG21/quickref/#error-suggestion) ([Understanding 3.3.3](/WAI/WCAG21/Understanding/error-suggestion))
 * **Tutorial**
-  * [User Notifications](/WAI/tutorials/forms/notifications/)
+  * [User Notifications](/tutorials/forms/notifications/)
 * **User Story**
   * [How making important content easily identifiable can help](/people-use-web/user-stories/#classroomstudent)
 
@@ -521,7 +533,7 @@ Use whitespace and proximity to make relationships between content more apparent
   * [Headings and Labels 2.4.6](/WAI/WCAG21/quickref/#headings-and-labels) ([Understanding 2.4.6](/WAI/WCAG21/Understanding/headings-and-labels))
   * [Section Headings 2.4.10](/WAI/WCAG21/quickref/#section-headings) ([Understanding 2.4.10](/WAI/WCAG21/Understanding/section-headings))
 * **Tutorial**
-  * [Headings](/WAI/tutorials/page-structure/headings/)
+  * [Headings](/tutorials/page-structure/headings/)
 * **User Story**
   * [Describes how headings can be helpful for navigation](/people-use-web/user-stories/#accountant)
 
@@ -600,7 +612,7 @@ Work with content authors and developers to provide alternatives for non-text co
 * **WCAG**
   * [Non-text Content 1.1.1](/WAI/WCAG21/quickref/#non-text-content) ([Understanding 1.1.1](/WAI/WCAG21/Understanding/non-text-content))
 * **Tutorial**
-  * [Images](/WAI/tutorials/images/)
+  * [Images](/tutorials/images/)
 * **User Story**
   * [Describes the value of text alternatives to a blind user](/people-use-web/user-stories/#accountant)
 
@@ -636,7 +648,7 @@ Provide visible controls to allow users to stop any animations or auto-playing s
   * [Audio Control 1.4.2](/WAI/WCAG21/quickref/#audio-control) ([Understanding 1.4.2](/WAI/WCAG21/Understanding/audio-control))
   * [Pause, Stop, Hide 2.2.2](/WAI/WCAG21/quickref/#pause-stop-hide) ([Understanding 2.2.2](/WAI/WCAG21/Understanding/pause-stop-hide))
 * **Tutorial**
-  * [Carousel Concepts](/WAI/tutorials/carousels/)
+  * [Carousel Concepts](/tutorials/carousels/)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -648,10 +660,10 @@ Provide visible controls to allow users to stop any animations or auto-playing s
 
 These tips are a few of the things you need to consider for web accessibility. The following resources help you learn why accessibility is important, and about guidelines for making the web more accessible to people with disabilities.
 
-* [Introduction to Web Accessibility](https://www.w3.org/WAI/fundamentals/accessibility-intro/) — covers broad issues, such as the business case, and links to helpful resources
-* [Accessibility Principles](/WAI/intro/people-use-web/principles) — introduces the concepts behind the web accessibility requirements
-* [How people with disabilities use the web](/WAI/intro/people-use-web) — explores the impact of accessible design with real-life examples
-* [Web Accessibility Tutorials](/WAI/tutorials/) — includes some guidance related to designing, for example, [providing alternative text for images](/WAI/tutorials/images/)
+* [Introduction to Web Accessibility](/fundamentals/accessibility-intro/) — covers broad issues, such as the business case, and links to helpful resources
+* [Accessibility Principles](/fundamentals/accessibility-principles/) — introduces the concepts behind the web accessibility requirements
+* [How people with disabilities use the web](/people-use-web/) — explores the impact of accessible design with real-life examples
+* [Web Accessibility Tutorials](/tutorials/) — includes some guidance related to designing, for example, [providing alternative text for images](/tutorials/images/)
 * [Before and After Demonstration](/WAI/demos/bad/) — shows an inaccessible and accessible version of the same website, with annotations on accessibility barriers and repairs
 * [How to Meet WCAG (Quick Reference)](/WAI/WCAG21/quickref/) — customizable reference of all WCAG requirements and techniques
 * [Web Accessibility Evaluation Tools List](/WAI/ER/tools/) — includes tools to help explore contrast ratio

--- a/_tips/designing.md
+++ b/_tips/designing.md
@@ -1,6 +1,6 @@
 ---
 # Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
-# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".title: Tips for Getting Started
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:"
 
 title: "Designing for Web Accessibility – Tips for Getting Started"
 title_html: "Designing for Web Accessibility"

--- a/_tips/developing.md
+++ b/_tips/developing.md
@@ -1,6 +1,6 @@
 ---
 # Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
-# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".title: Tips for Getting Started
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:"
 
 title: "Developing for Web Accessibility – Tips for Getting Started"
 title_html: "Developing for Web Accessibility"
@@ -123,7 +123,7 @@ Ensure that alternative text for images is added to all informational and functi
 * **Tutorial**
   * [Images](/tutorials/images/)
 * **User Story**
-  * [Describes the value of text alternatives to a blind user](//people-use-web/stories#accountant)
+  * [Describes the value of text alternatives to a blind user](/people-use-web/user-stories/#accountant)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -245,7 +245,7 @@ Use appropriate mark-up for headings, lists, tables, etc. HTML5 provides additio
   * [Page Structure](/tutorials/page-structure/)
   * [Tables](/tutorials/tables/)
 * **User Story**
-  * [Describes how structural information helps a screen reader user](//people-use-web/stories#accountant)
+  * [Describes how structural information helps a screen reader user](/people-use-web/user-stories/#accountant)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -298,7 +298,7 @@ Be as forgiving of format as possible when processing user input. For example, a
 * **Tutorial**
   * [Validating Input](/tutorials/forms/validation/)
 * **User Story**
-  * [Describes how helpful errors help a user with dyslexia](//people-use-web/stories#classroomstudent)
+  * [Describes how helpful errors help a user with dyslexia](/people-use-web/user-stories/#classroomstudent)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -456,7 +456,7 @@ Use responsive design to adapt the display to different zoom states and viewport
 * **Background**
   * [Small Screen Size](/TR/mobile-accessibility-mapping/#h-small-screen-size)
 * **User Story**
-  * [Describes how alternative views of zoomed pages can be helpful](//people-use-web/stories#retiree)
+  * [Describes how alternative views of zoomed pages can be helpful](/people-use-web/user-stories/#retiree)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -591,7 +591,7 @@ buttonExample.addEventListener('click', function(e) {
 * **WCAG**
   * [Keyboard 2.1.1](/WAI/WCAG21/quickref/#keyboard) ([Understanding 2.1.1](/WAI/WCAG21/Understanding/keyboard))
 * **User Story**
-  * [Describes how a user with RSI needs keyboard support](//people-use-web/stories#reporter)
+  * [Describes how a user with RSI needs keyboard support](/people-use-web/user-stories/#reporter)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -631,7 +631,7 @@ These tips are a few of the things you need to consider for web accessibility. T
 * [Before and After Demonstration](/WAI/demos/bad/) — Example accessible and inaccessible websites that share the same visual design, with annotations that highlight key accessibility barriers and repairs, and evaluation reports for <abbr>WCAG</abbr>
 * [How to Meet WCAG (Quick Reference)](/WAI/WCAG21/quickref/) — customizable reference of all WCAG requirements and techniques
 * [Web Accessibility Evaluation Tools List](/WAI/ER/tools/) — Provides a range of tools to help explore the accessibility of code
-* [<abbr>WAI-ARIA</abbr> Overview](/WAI/intro/aria) — Introduction to <abbr>WAI-ARIA</abbr> with links to all the specifications
+* [<abbr>WAI-ARIA</abbr> Overview](/standards-guidelines/aria/) — Introduction to <abbr>WAI-ARIA</abbr> with links to all the specifications
 
 {::nomarkdown}
 {% include box.html type="end" %}

--- a/_tips/developing.md
+++ b/_tips/developing.md
@@ -1,18 +1,20 @@
 ---
-# Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after #.
-# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".
+# Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".title: Tips for Getting Started
 
 title: "Developing for Web Accessibility – Tips for Getting Started"
 title_html: "Developing for Web Accessibility"
 nav_title: "Tips for Developing"
-
-title_icon: /tips/img/icons.svg#developing
-ext_css: tips.css
-
-lang: en   # Change "en" to the translated-language shortcode from https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+lang: en  # Change "en" to the translated-language shortcode
 last_updated: 2019-01-09   # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
-# translators:    # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
+resource:
+  ref: /tips/
+
+navigation:
+  previous: /tips/designing/
+
+# translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
 # - name: "Jan Doe"   # Replace Jan Doe with translator name
 # - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple translators
 # contributors:
@@ -21,29 +23,25 @@ last_updated: 2019-01-09   # Put the date of this translation YYYY-MM-DD (with m
 
 github:
   repository: w3c/wai-quick-start
-  path: _tips/developing.md    # Add the language shortcode to the middle of the filename, for example: _tips/developing.fr.md
-permalink: /tips/developing/   # Add the language shortcode to the end, with no slash at end, for example: /tips/developing/fr
+  path: _tips/developing.md    # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
+  
+permalink: /tips/developing/   # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
+ref: /tips/developing/  # Do not change this
 
-resource:
-  ref: /tips/
-navigation:
-  previous: /tips/designing/
-#next: /tips/…/
+ext_css: tips.css
+title_icon: /tips/img/icons.svg#developing
 
-ref: /tips/developing/   # Translators, do not change this
-# changelog: /@@/changelog/
-# acknowledgements: /tips/acknowledgements/ 
+acknowledgements: /tips/acknowledgements/
 
 # In the footer below:
-# Do not translate or change CHANGELOG or ACKNOWLEDGEMENTS.
-# Translate the other words below, including "Date:" and "Editor:"
+# Do not change the dates
+# Do not translate ACKNOWLEDGEMENTS
+# Translate the other words, including "Date:" and "Editors:"
 # Translate the Working Group name. Leave the Working Group acronym in English.
-# Do not change the dates in the footer below.
 footer: >
   <p><strong>Date:</strong> Minor update 9 January 2019. Updated 15 April 2016. First published September 2015.</p>
-  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/kevin">Kevin White</a>, <a href="https://www.w3.org/People/shadi">Shadi Abou-Zahra</a>, and <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. <a href="/wai/tips/acknowledgements/">Acknowledgements</a> lists contributors and credits.</p>
+  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/kevin">Kevin White</a>, <a href="https://www.w3.org/People/shadi">Shadi Abou-Zahra</a>, and <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. ACKNOWLEDGEMENTS lists contributors and credits.</p>
   <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>). Developed as part of the <a href="https://www.w3.org/WAI/DEV/">WAI-DEV project</a>, co-funded by the European Commission.</p>
-
 ---
 
 {::nomarkdown}
@@ -106,7 +104,7 @@ Use a `for` attribute on the `<label>` element linked to the `id` attribute of t
 * **WCAG**
   * [Labels or Instructions 3.3.2](/WAI/WCAG21/quickref/#labels-or-instructions) ([Understanding 3.3.2](/WAI/WCAG21/Understanding/labels-or-instructions))
 * **Tutorial**
-  * [Labeling Controls](/WAI/tutorials/forms/labels/)
+  * [Labeling Controls](/tutorials/forms/labels/)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -123,9 +121,9 @@ Ensure that alternative text for images is added to all informational and functi
 * **WCAG**
   * [Non-text Content 1.1.1](/WAI/WCAG21/quickref/#non-text-content) ([Understanding 1.1.1](/WAI/WCAG21/Understanding/non-text-content))
 * **Tutorial**
-  * [Images](/WAI/tutorials/images/)
+  * [Images](/tutorials/images/)
 * **User Story**
-  * [Describes the value of text alternatives to a blind user](/WAI/intro/people-use-web/stories#accountant)
+  * [Describes the value of text alternatives to a blind user](//people-use-web/stories#accountant)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -244,10 +242,10 @@ Use appropriate mark-up for headings, lists, tables, etc. HTML5 provides additio
 * **WCAG**
   * [Info and Relationships 1.3.1](/WAI/WCAG21/quickref/#info-and-relationships) ([Understanding 1.3.1](/WAI/WCAG21/Understanding/info-and-relationships))
 * **Tutorial**
-  * [Page Structure](/WAI/tutorials/page-structure/)
-  * [Tables](/WAI/tutorials/tables/)
+  * [Page Structure](/tutorials/page-structure/)
+  * [Tables](/tutorials/tables/)
 * **User Story**
-  * [Describes how structural information helps a screen reader user](/WAI/intro/people-use-web/stories#accountant)
+  * [Describes how structural information helps a screen reader user](//people-use-web/stories#accountant)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -298,9 +296,9 @@ Be as forgiving of format as possible when processing user input. For example, a
 * **WCAG**
   * [Error Identifications 3.3.1](/WAI/WCAG21/quickref/#error-identification) ([Understanding 3.3.1](/WAI/WCAG21/Understanding/error-identification))
 * **Tutorial**
-  * [Validating Input](/WAI/tutorials/forms/validation/)
+  * [Validating Input](/tutorials/forms/validation/)
 * **User Story**
-  * [Describes how helpful errors help a user with dyslexia](/WAI/intro/people-use-web/stories#classroomstudent)
+  * [Describes how helpful errors help a user with dyslexia](//people-use-web/stories#classroomstudent)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -458,7 +456,7 @@ Use responsive design to adapt the display to different zoom states and viewport
 * **Background**
   * [Small Screen Size](/TR/mobile-accessibility-mapping/#h-small-screen-size)
 * **User Story**
-  * [Describes how alternative views of zoomed pages can be helpful](/WAI/intro/people-use-web/stories#retiree)
+  * [Describes how alternative views of zoomed pages can be helpful](//people-use-web/stories#retiree)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -593,7 +591,7 @@ buttonExample.addEventListener('click', function(e) {
 * **WCAG**
   * [Keyboard 2.1.1](/WAI/WCAG21/quickref/#keyboard) ([Understanding 2.1.1](/WAI/WCAG21/Understanding/keyboard))
 * **User Story**
-  * [Describes how a user with RSI needs keyboard support](/WAI/intro/people-use-web/stories#reporter)
+  * [Describes how a user with RSI needs keyboard support](//people-use-web/stories#reporter)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -626,10 +624,10 @@ CAPTCHAs create problems for many people. There are other means of verifying tha
 
 These tips are a few of the things you need to consider for web accessibility. The following resources help you learn why accessibility is important, and about guidelines for making the web more accessible to people with disabilities.
 
-* [Introduction to Web Accessibility](https://www.w3.org/WAI/fundamentals/accessibility-intro/) — Introduces accessibility and provides links to many helpful resources
-* [Accessibility Principles](/WAI/intro/people-use-web/principles) — An introduction to the <abbr>WCAG</abbr> requirements
-* [How people with disabilities use the web](/WAI/intro/people-use-web) — Real-life examples of the benefits of accessibility for people with disabilities
-* [Web Accessibility Tutorials](/WAI/tutorials/) — Shows you how to develop web content that is accessible to people with disabilities
+* [Introduction to Web Accessibility](/fundamentals/accessibility-intro/) — Introduces accessibility and provides links to many helpful resources
+* [Accessibility Principles](/fundamentals/accessibility-principles/) — An introduction to the <abbr>WCAG</abbr> requirements
+* [How people with disabilities use the web](/people-use-web/) — Real-life examples of the benefits of accessibility for people with disabilities
+* [Web Accessibility Tutorials](/tutorials/) — Shows you how to develop web content that is accessible to people with disabilities
 * [Before and After Demonstration](/WAI/demos/bad/) — Example accessible and inaccessible websites that share the same visual design, with annotations that highlight key accessibility barriers and repairs, and evaluation reports for <abbr>WCAG</abbr>
 * [How to Meet WCAG (Quick Reference)](/WAI/WCAG21/quickref/) — customizable reference of all WCAG requirements and techniques
 * [Web Accessibility Evaluation Tools List](/WAI/ER/tools/) — Provides a range of tools to help explore the accessibility of code

--- a/_tips/index.md
+++ b/_tips/index.md
@@ -1,6 +1,6 @@
 ---
 # Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
-# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".title: Tips for Getting Started
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".
 
 title: Tips for Getting Started
 nav_title: Overview

--- a/_tips/index.md
+++ b/_tips/index.md
@@ -1,20 +1,39 @@
 ---
+# Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".title: Tips for Getting Started
+
 title: Tips for Getting Started
 nav_title: Overview
-permalink: /tips/
-ref: /tips/
-lang: en
+lang: en # Change "en" to the translated-language shortcode
+last_updated: 2016-07-07 # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
 resource:
   title: "Tips for Getting Started"
-  ref: /tips/
+  ref: /tips/ # Do not change this
+
 navigation:
-  next: /tips/writing/
+  next: /tips/writing/ # Do not change this
+
+# translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
+# - name: "Jan Doe"   # Replace Jan Doe with translator name
+# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple translators
+# contributors:
+# - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
+# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
 github:
    repository: w3c/wai-quick-start
-   path: '_tips/index.md'   # add language code index.@@.md
+   path: '_tips/index.md' # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
 
+permalink: /tips/ # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
+ref: /tips/ # Do not change this
+
+acknowledgements: /tips/acknowledgements/
+
+# In the footer below:
+# Do not change the dates
+# Translate the other words, including "Status:" and "Editors:"
+# Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p>
     <strong>Status:</strong>
@@ -26,7 +45,7 @@ footer: >
     <a href="https://www.w3.org/People/#kevin">Kevin White</a>,
     <a href="https://www.w3.org/People/shadi">Shadi Abou-Zahra</a>, and
     <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a>.
-    <a href="./acknowledgements/">Acknowledgements</a>.
+    ACKNOWLEDGEMENTS.
     Developed by the <a href="https://www.w3.org/WAI/EO/">Education and Outreach Working Group (EOWG)</a>.
     Developed with support from the <a href="https://www.w3.org/WAI/DEV/">WAI-DEV project</a>, co-funded by the European Commission <abbr title="Information Society Technologies">IST</abbr> Programme.
   </p>

--- a/_tips/writing.md
+++ b/_tips/writing.md
@@ -1,40 +1,47 @@
 ---
+# Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".title: Tips for Getting Started
+
 title: "Writing for Web Accessibility – Tips for Getting Started"
 title_html: "Writing for Web Accessibility"
 nav_title: Tips for Writing
+lang: en  # Change "en" to the translated-language shortcode
+last_updated: 2022-08-05  # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
-ref: /tips/writing/   # Do not change this
-permalink: /tips/writing/   # add language code  /tips/writing/@@
-lang: en
-navigation:
-  previous: /tips/
-  next: /tips/designing/
 resource:
-  ref: /tips/
+  ref: /tips/  # Do not change this
+
 navigation:
-  previous: /tips/
-  next:     /tips/designing/
+  previous: /tips/  # Do not change this
+  next: /tips/designing/  # Do not change this
 
-lang: en   # change language code
-github:
-   repository: w3c/wai-quick-start
-   path: '_tips/writing.md'   # add language code writing.@@.md
-last_updated: 2022-08-05   # change to date of translation
-# translators:
-# - name: "Your Name"
+# translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
+# - name: "Jan Doe"   # Replace Jan Doe with translator name
+# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple translators
 # contributors:
-# - name: "Other Name"
+# - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
+# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
-layout: default
-order: 2
+github:
+  repository: w3c/wai-quick-start
+  path: '_tips/writing.md'  # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
+
+permalink: /tips/writing/   # Add the language shortcode to the end, with no slash at the end. For example /path/to/file/fr
+ref: /tips/writing/   # Do not change this
+
 ext_css: tips.css
 title_icon: /tips/img/icons.svg#writing
 
-footer: >   # translate text and dates; do not update dates
-  <p><strong>Date:</strong> Updated 5 August 2022. First published September 2015.</p>
-  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/kevin">Kevin White</a>, <a href="https://www.w3.org/People/shadi">Shadi Abou-Zahra</a>, and <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. <a href="https://w3c.github.io/wai-website/tips/acknowledgements/">Acknowledgements</a>.</p>
-  <p>Developed by the <a href="https://www.w3.org/WAI/EO/">Education and Outreach Working Group (EOWG)</a>. Developed with support from the <a href="https://www.w3.org/WAI/DEV/">WAI-DEV project</a>, co-funded by the European Commission <abbr title="Information Society Technologies">IST</abbr> Programme.</p>
+acknowledgements: /tips/acknowledgements/
 
+# In the footer below:
+# Do not change the dates
+# Translate the other words, including "Date:" and "Editors:"
+# Translate the Working Group name. Leave the Working Group acronym in English.
+footer: >
+  <p><strong>Date:</strong> Updated 5 August 2022. First published September 2015.</p>
+  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/kevin">Kevin White</a>, <a href="https://www.w3.org/People/shadi">Shadi Abou-Zahra</a>, and <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. ACKNOWLEDGEMENTS.</p>
+  <p>Developed by the <a href="https://www.w3.org/WAI/EO/">Education and Outreach Working Group (EOWG)</a>. Developed with support from the <a href="https://www.w3.org/WAI/DEV/">WAI-DEV project</a>, co-funded by the European Commission <abbr title="Information Society Technologies">IST</abbr> Programme.</p>
 ---
 
 {::nomarkdown}
@@ -214,7 +221,7 @@ View inline example
   * [Section Headings 2.4.10](/WAI/WCAG21/quickref/#section-headings) ([Understanding 2.4.10](/WAI/WCAG21/Understanding/section-headings))
   * [Info and Relationships 1.3.1](/WAI/WCAG21/quickref/#info-and-relationships) ([Understanding 1.3.1](/WAI/WCAG21/Understanding/info-and-relationships))
 * **User Story**
-  * [How a screen reader user uses headings to navigate]({{ "/people-use-web/user-stories/" | relative_url }}#accountant)
+  * [How a screen reader user uses headings to navigate](/people-use-web/user-stories/#accountant)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -302,9 +309,9 @@ For every image, write alternative text that provides the information or functio
 * **WCAG**
   * [Non-text Content 1.1.1](/WAI/WCAG21/quickref/#non-text-content) ([Understanding 1.1.1](/WAI/WCAG21/Understanding/non-text-content))
 * **Tutorial**
-  * [Images](/WAI/tutorials/images/)
+  * [Images](/tutorials/images/)
 * **User Story**
-  * [Describes the value of text alternatives to a blind user]({{ "/people-use-web/user-stories/" | relative_url }}#accountant)
+  * [Describes the value of text alternatives to a blind user](/people-use-web/user-stories/#accountant)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -324,7 +331,7 @@ For audio-only content, such as a podcast, provide a transcript. For audio and v
   * [Captions (Prerecorded) 1.2.2](/WAI/WCAG21/quickref/#captions-prerecorded) ([Understanding 1.2.2](/WAI/WCAG21/Understanding/captions-prerecorded))
   * [Audio Description or Media Alternative (Prerecorded) 1.2.3](/WAI/WCAG21/quickref/#audio-description-or-media-alternative-prerecorded) ([Understanding 1.2.3](/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded))
 * **User Story**
-  * [Describes how captions help a deaf student]({{ "/people-use-web/user-stories/#onlinestudent" | relative_url }})
+  * [Describes how captions help a deaf student](/people-use-web/user-stories/#onlinestudent)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -382,7 +389,7 @@ Ensure that instructions, guidance, and error messages are clear, easy to unders
 * **WCAG**
   * [Labels or Instructions 3.3.2](/WAI/WCAG21/quickref/#labels-or-instructions) ([Understanding 3.3.2](/WAI/WCAG21/Understanding/labels-or-instructions))
 * **User Story**
-  * [Describes simple instructions help someone with learning difficulties]({{ "/people-use-web/user-stories/" | relative_url }}#supermarketassistant)
+  * [Describes simple instructions help someone with learning difficulties](/people-use-web/user-stories/#supermarketassistant)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -438,7 +445,7 @@ Use simple language and formatting, as appropriate for the context.
   * [Unusual Words 3.1.3](/WAI/WCAG21/quickref/#unusual-words) ([Understanding 3.1.3](/WAI/WCAG21/Understanding/unusual-words))
   * [Abbreviations 3.1.4](/WAI/WCAG21/quickref/#abbreviations) ([Understanding 3.1.4](/WAI/WCAG21/Understanding/abbreviations))
 * **User Story**
-  * [User with reading disabilities benefits from easy to read text]({{ "/people-use-web/user-stories/" | relative_url }}#classroomstudent)
+  * [User with reading disabilities benefits from easy to read text](/people-use-web/user-stories/#classroomstudent)
 
 {::nomarkdown}
 {% include_cached box.html type="end" %}
@@ -452,9 +459,9 @@ These tips are a few of the things you need to consider for web accessibility. A
 
 The following resources help you learn why accessibility is important, and about guidelines for making the web more accessible to people with disabilities.
 
-* [Accessibility Introduction]({{ "/fundamentals/accessibility-intro/" | relative_url }}) — Introduces accessibility and provides links to many helpful resources
-* [Accessibility Principles]({{ "/fundamentals/accessibility-intro/" | relative_url }}) — An introduction to the <abbr>WCAG</abbr> requirements
-* [How people with disabilities use the web]({{ "/people-use-web/" | relative_url }}) — Real-life examples showing the importance of accessibility for people with disabilities
+* [Accessibility Introduction](/fundamentals/accessibility-intro/) — Introduces accessibility and provides links to many helpful resources
+* [Accessibility Principles](/fundamentals/accessibility-principles/) — An introduction to the <abbr>WCAG</abbr> requirements
+* [How people with disabilities use the web](/people-use-web/) — Real-life examples showing the importance of accessibility for people with disabilities
 * [How to Meet WCAG (Quick Reference)](/WAI/WCAG21/quickref/) — customizable reference of all WCAG requirements and techniques
 
 {::nomarkdown}

--- a/_tips/writing.md
+++ b/_tips/writing.md
@@ -1,6 +1,6 @@
 ---
 # Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
-# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".title: Tips for Getting Started
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".
 
 title: "Writing for Web Accessibility – Tips for Getting Started"
 title_html: "Writing for Web Accessibility"


### PR DESCRIPTION
- Add comments for translators in frontmatter
- Use `ACKNOWLEDGEMENTS` placeholder in footer
- Add missing `last_updated` attribute in some pages
- Delete useless `order` and `layout` attributes in `writing.md`
- Use relative links when linked-to page is in WAI website.
- Fix "Accessibility principles" link in `writing.md`